### PR TITLE
support multiSet

### DIFF
--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -24,6 +24,11 @@ jest.setMock('react-native', {
 				resolve(null);
 			});
 		}),
+		multiSet:  jest.fn(() => {
+			return new Promise((resolve, reject) => {
+				resolve(null);
+			});
+		}),
 		getItem: jest.fn(() => {
 			return new Promise((resolve, reject) => {
 				resolve(JSON.stringify(getTestData()));
@@ -52,6 +57,13 @@ describe('save', function() {
 	it('should return a promise with no errors', function() {
 		var store = require(INDEX_PATH);
 		return store.save('testing', getTestData()).then(function(error) {
+			expect(error).toEqual(null);
+		});
+	});
+
+	it('should return a promise with no errors', function() {
+		var store = require(INDEX_PATH);
+		return store.save(multiGetTestData()).then(function(error) {
 			expect(error).toEqual(null);
 		});
 	});

--- a/src/index.js
+++ b/src/index.js
@@ -27,12 +27,19 @@ const deviceStorage = {
 
 	/**
 	 * Save a key value pair to AsyncStorage.
-	 * @param  {String} key The key
+	 * @param  {String|Array} key The key or an array of key/value pairs
 	 * @param  {Any} value The value to save
 	 * @return {Promise}
 	 */
 	save(key, value) {
-		return AsyncStorage.setItem(key, JSON.stringify(value));
+        if(!Array.isArray(key)) {
+            return AsyncStorage.setItem(key, JSON.stringify(value));
+        } else {
+            var kvPairs = key.map(function(kvPair) {
+                return [kvPair[0], JSON.stringify(kvPair[1])];
+            });
+            return AsyncStorage.multiSet(kvPairs);
+        }
 	},
 
 	/**

--- a/src/index.js
+++ b/src/index.js
@@ -32,14 +32,14 @@ const deviceStorage = {
 	 * @return {Promise}
 	 */
 	save(key, value) {
-        if(!Array.isArray(key)) {
-            return AsyncStorage.setItem(key, JSON.stringify(value));
-        } else {
-            var kvPairs = key.map(function(kvPair) {
-                return [kvPair[0], JSON.stringify(kvPair[1])];
-            });
-            return AsyncStorage.multiSet(kvPairs);
-        }
+		if(!Array.isArray(key)) {
+			return AsyncStorage.setItem(key, JSON.stringify(value));
+		} else {
+			var kvPairs = key.map(function(kvPair) {
+				return [kvPair[0], JSON.stringify(kvPair[1])];
+			});
+			return AsyncStorage.multiSet(kvPairs);
+		}
 	},
 
 	/**


### PR DESCRIPTION
Add support for using an array of key/value pairs passed to `save()`. JSON stringifys the value in each pair to be consistent with the setItem behaviour 