### PR TITLE
Adds the ability to pass default value(s) to `get`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ npm install react-native-simple-store
 import store from 'react-native-simple-store';
 
 store
+  .get('coffee', { needMore: true })
+  .then(coffee => {
+    console.assert(coffee.needMore === true);
+  })
   .save('coffee', {
     isAwesome: true
   })

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -40,14 +40,23 @@ jest.mock('react-native', () => ({
 				resolve(null);
 			});
 		}),
-		getItem: jest.fn(() => {
+		getItem: jest.fn(testKey => {
+			let returnValue = {
+				testing: JSON.stringify(getTestData()),
+				testingDefault: null
+			};
+
 			return new Promise((resolve, reject) => {
-				resolve(JSON.stringify(getTestData()));
+				resolve(returnValue[testKey]);
 			});
 		}),
-		multiGet: jest.fn(() => {
+		multiGet: jest.fn(testKeys => {
+			let returnValue = {
+				testing: multiGetTestData(),
+				testingDefault: [['testingDefault', null], ['testingDefault', null]]
+			}
 			return new Promise((resolve, reject) => {
-				resolve(multiGetTestData());
+				resolve(returnValue[testKeys[1]]);
 			});
 		}),
 		removeItem: jest.fn(() => {
@@ -92,21 +101,41 @@ describe('save', () => {
 
 describe('get', () => {
 
+	const { AsyncStorage } = require('react-native');
+	const store = require(INDEX_PATH);
+
 	it('should return a promise with saved data', () => {
-		const { AsyncStorage } = require('react-native');
-		const store = require(INDEX_PATH);
 		return store.get('testing').then((error) => {
 			expect(error).toEqual(getTestData());
 			expect(AsyncStorage.getItem).toBeCalledWith('testing');
 		});
 	});
 
+	it('should return the default value if no saved data', () => {
+		return store.get('testingDefault', 'defaultValue').then(result => {
+			expect(result).toEqual('defaultValue');
+			expect(AsyncStorage.getItem).toBeCalledWith('testingDefault');
+		});
+	});
+
 	it('should return a promise with saved data', () => {
-		const { AsyncStorage } = require('react-native');
-		const store = require(INDEX_PATH);
 		return store.get(['testing', 'testing']).then((error) => {
 			expect(error).toEqual([{valor: 1}, {valor: 2}]);
 			expect(AsyncStorage.multiGet).toBeCalledWith(['testing', 'testing']);
+		});
+	});
+
+	it('should return the default value for multiple keys if no saved data', () => {
+		return store.get(['testingDefault', 'testingDefault'], 'defaultValue').then(result => {
+			expect(result).toEqual(['defaultValue', 'defaultValue']);
+			expect(AsyncStorage.multiGet).toBeCalledWith(['testingDefault', 'testingDefault']);
+		});
+	});
+
+	it('should return the default value for multiple keys if no saved data', () => {
+		return store.get(['testingDefault', 'testingDefault'], ['defaultValue1', 'defaultValue2']).then(result => {
+			expect(result).toEqual(['defaultValue1', 'defaultValue2']);
+			expect(AsyncStorage.multiGet).toBeCalledWith(['testingDefault', 'testingDefault']);
 		});
 	});
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,13 +6,15 @@
 
 * * *
 
-### get(key) 
+### get(key, defaultValue) 
 
 Get a one or more value for a key or array of keys from AsyncStorage
 
 **Parameters**
 
 **key**: `String | Array`, A key or array of keys
+
+**defaultValue**: `String | Array`, Returned if the key(s) are null
 
 **Returns**: `Promise`
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,17 +10,19 @@ const deviceStorage = {
 	/**
 	 * Get a one or more value for a key or array of keys from AsyncStorage
 	 * @param {String|Array} key A key or array of keys
+	 * @param {String|Array} [defaultValue] Returned if the key(s) are null
 	 * @return {Promise}
 	 */
-	get(key) {
+	get(key, defaultValue) {
 		if(!Array.isArray(key)) {
 			return AsyncStorage.getItem(key).then(value => {
-				return JSON.parse(value);
+				return JSON.parse(value) || defaultValue;
 			});
 		} else {
 			return AsyncStorage.multiGet(key).then(values => {
-				return values.map(value => {
-					return JSON.parse(value[1]);
+				return values.map((value, index) => {
+					var defaultMulti = Array.isArray(defaultValue) ? defaultValue[index] : defaultValue;
+					return JSON.parse(value[1]) || defaultMulti;
 				});
 			});
 		}


### PR DESCRIPTION
In some cases, particularly when storing an object, it's useful to have a default state. This prevents the need for extra conditionals to avoid `null is not an object` after the unset state is returned.

This adds the ability to pass an optional `defaultValue` parameter to the `get` function. This also works on multi-key gets with either a single object (will be returned as the default value for all keys) or an array (the matching index will be returned as the default value)

Updated the documentation and tests. The mock modifications feel like they could be done a bit better but I was trying to keep changes minimal for now.