### PR TITLE
Add ES6 Map support for saving it as an object

### DIFF
--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -8,6 +8,7 @@ const returnValues = {
 		}
 	}),
 	stringOne: JSON.stringify('testing string'),
+	testMap: JSON.stringify({1: 'one', 2: 'two'}),
 };
 
 function multiGetTestData() {
@@ -103,6 +104,17 @@ describe('index.js', () => {
 			return store.save(multiSaveTestData()).then((error) => {
 				expect(error).toEqual(null);
 				expect(AsyncStorage.multiSet).toBeCalledWith(result);
+			});
+		});
+
+		it('should save an ES6 Map as an object', () => {
+			let testMap = new Map();
+			testMap.set(1, 'one');
+			testMap.set(2, 'two');
+
+			return store.save('testMap', testMap).then((error) => {
+				expect(error).toEqual(null);
+				expect(AsyncStorage.setItem).toBeCalledWith('testMap', returnValues.testMap);
 			});
 		});
 

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,15 @@ const deviceStorage = {
 	 * @return {Promise}
 	 */
 	save(key, value) {
+		if (value instanceof Map) {
+			let obj = Object.create(null);
+
+			for (let [k, v] of value) {
+				obj[k] = v;
+			}
+
+			return AsyncStorage.setItem(key, JSON.stringify(obj));
+		}
 		if(!Array.isArray(key)) {
 			return AsyncStorage.setItem(key, JSON.stringify(value));
 		} else {


### PR DESCRIPTION
This update allows to save ES6 Maps as objects to AsyncStorage.

**Discussion**: there's no possibility to detect when getting the value from AsyncStorage whether it has been saved as an object or as a Map instance.

Should there be a prop somewhere what tells the data type?