### PR TITLE
fix bundling failure due to api.cache

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,6 @@
 module.exports = (api) => {
-	api.cache(true);
-
+	//api.cache(true);
+	// throws bundling failed: TypeError: Cannot read property 'cache' of undefined is same cases
 	return {
 		presets: [
 			"@babel/preset-env",

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,9 @@
 module.exports = (api) => {
-	//api.cache(true);
+
+	if (api && api.cache) {
+		api.cache(true);
+	}
+	
 	// throws bundling failed: TypeError: Cannot read property 'cache' of undefined is same cases
 	return {
 		presets: [


### PR DESCRIPTION
fix the bundling failed: TypeError: Cannot read property 'cache' of undefined