### PR TITLE
Adds react-native-async-storage as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   "author": "Jason Merino",
   "license": "MIT",
   "dependencies": {
-    "lodash.merge": "4.6.0"
+    "lodash.merge": "4.6.0",
+    "@react-native-community/async-storage": "1.3.3"
   },
   "devDependencies": {
     "@babel/core": "^7.4.3",
@@ -44,7 +45,6 @@
     "jest": "^24.7.1",
     "jsdox": "^0.4.10",
     "react": "16.8.3",
-    "react-native": "0.59.5",
-    "@react-native-community/async-storage": "^1.3.3"
+    "react-native": "0.59.10"
   }
 }


### PR DESCRIPTION
It was added as a dev dependency, but should be added as the regular
dependency. Closes #57

Also updated the react-native version to 0.59.10